### PR TITLE
rain gauge relative to precip at initialize!

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -63,21 +63,28 @@ open(joinpath(@__DIR__, "src/submissions.md"), "w") do mdfile
 
     nsubmissions = length(all_submissions)
 
-    for (name, dict) in all_submissions
-        author = dict["author"]
-        description = dict["description"]
-        rank = dict["rank"]
-        println(mdfile, "## $author: $description\n")
-        println(mdfile, "path: /submissions/$name.jl\n")
-        println(mdfile, "rank: $rank. of $nsubmissions submissions\n")
-        println(mdfile, "```@example $name")
-        println(mdfile, "using CairoMakie # hide")
-        println(mdfile, dict["code"])
-        println(mdfile, "RainMaker.plot(rain_gauge) # hide")
-        println(mdfile, """save("submission_$name.png", ans) # hide""")
-        println(mdfile, "nothing # hide")
-        println(mdfile, "```")
-        println(mdfile, "![submission: $name](submission_$name.png)\n")
+    # instead of sorting the dictionary, we iterate over the ranks
+    for i in 1:nsubmissions
+        # then find the submission with the given rank
+        for (name, dict) in all_submissions
+            rank = dict["rank"]
+            if rank == i
+                author = dict["author"]
+                description = dict["description"]
+                rank = dict["rank"]
+                println(mdfile, "## $author: $description\n")
+                println(mdfile, "path: `/submissions/$name.jl`\n")
+                println(mdfile, "rank: $rank. of $nsubmissions submissions\n")
+                println(mdfile, "```@example $name")
+                println(mdfile, "using CairoMakie # hide")
+                println(mdfile, dict["code"])
+                println(mdfile, "RainMaker.plot(rain_gauge) # hide")
+                println(mdfile, """save("submission_$name.png", ans) # hide""")
+                println(mdfile, "nothing # hide")
+                println(mdfile, "```")
+                println(mdfile, "![submission: $name](submission_$name.png)\n")
+            end
+        end
     end
 end
 


### PR DESCRIPTION
Allows one to discard spinup, e.g.

![image](https://github.com/user-attachments/assets/cab22798-2075-481d-b0c2-01c546ea503b)

via

```julia
using SpeedyWeather, RainMaker
spectral_grid = SpectralGrid(trunc=31, nlayers=8)
model = PrimitiveWetModel(spectral_grid)
simulation = initialize!(model)
run!(simulation, period=Day(20))    # run without rain gauge

# now add rain gauge, initialized relative to accumulated precipitation of simulation at this point
rain_gauge = RainGauge(spectral_grid, lond=-1.25, latd=51.75)
add!(model, rain_gauge)

# hence record day 20-40 of a simulation
run!(simulation, period=Day(20))
```

which yields

```julia
julia> rain_gauge
RainGauge{Float32, AnvilInterpolator{Float32, OctahedralGaussianGrid}} <: AbstractCallback
├ latd::Float64 = 51.75˚N
├ lond::Float64 = -1.25˚E
├ measurement_counter:Int = 960 (now: 2000-02-10 00:00:00)
├ tstart::DateTime = 2000-01-21T00:00:00
├ Δt::Second 1800 seconds
├ max_measurements::Int = 100000 (measuring for up to ~5.7 years, 1% recorded)
├ accumulated_rain_large_scale::Vector{Float32}, maximum: 0.20487653 mm
├ accumulated_rain_convection::Vector{Float32}, maximum: 32.44758 mm
└ accumulated total precipitation: 32.652 mm
```