### PR TITLE
Update to SpeedyWeather v0.22, distinguish rain and snow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RainMaker"
 uuid = "ce1e5628-4095-449b-8858-623a1e420393"
+version = "0.3.0"
 authors = ["Milan Klöwer <milankloewer@gmx.de> and contributors"]
-version = "0.2.2"
 
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
@@ -13,8 +13,8 @@ SpeedyWeather = "9e226e20-d153-4fed-8a5b-493def4f21a9"
 [compat]
 CairoMakie = "0.15"
 DocStringExtensions = "0.9"
-SpeedyWeather = "0.16"
-julia = "1.10, 1.11"
+SpeedyWeather = "0.22"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In short,
 using SpeedyWeather, RainMaker
 
 # create a model
-spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 model = PrimitiveWetModel(spectral_grid)
 
 # add the rain gauge as callback

--- a/docs/headers/leaderboard_header.md
+++ b/docs/headers/leaderboard_header.md
@@ -10,5 +10,5 @@ code and RainMaker plots [Visualising RainGauge measurements](@ref).
 
 ## Leaderboard
 
-| Rank | Author | Description | Location | Total precipitation [mm] | Share convection [%] | Period [days] |
-| :--- | :----- | :---------- | :------- | -----------------------: | -------------------: | ------------: |
+| Rank | Author | Description | Location | Total precipitation [mm] | Share convection [%] | Share snow [%] | Period [days] |
+| :--- | :----- | :---------- | :------- | -----------------------: | -------------------: | -------------: | ------------: |

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,16 +20,17 @@ function run_submission(path::String)
     RainMaker.skip!(rain_gauge, SKIP_START)
 
     # analyse/evaluate, skip first five days of measurements
-    lsc = rain_gauge.accumulated_rain_large_scale
     conv = rain_gauge.accumulated_rain_convection
+    snow = rain_gauge.accumulated_snow_large_scale
 
-    total_precip = maximum(lsc) + maximum(conv)
+    total_precip = maximum_precipitation(rain_gauge)
     submission_dict = Dict(
         "author" => author,
         "description" => description,
         "location" => (rain_gauge.lond, rain_gauge.latd),
         "total precipitation" => total_precip,
         "convection share" => maximum(conv) / total_precip,
+        "snow share" => maximum(snow) / total_precip,
         "period" => Second(rain_gauge.measurement_counter*rain_gauge.Δt) - Second(SKIP_START),
         "path" => path,
         "code" => read(path, String),
@@ -117,8 +118,9 @@ open(joinpath(@__DIR__, "src/leaderboard.md"), "w") do mdfile
                 location = @sprintf("%.2f˚N, %.2f˚E", loc[2], loc[1])
                 total_precip = @sprintf("%.3f", dict["total precipitation"])
                 convection_share = @sprintf("%.1f", 100*dict["convection share"])
+                snow_share = @sprintf("%.1f", 100*dict["snow share"])
                 n_days = @sprintf("%d", Second(dict["period"]).value / 24 / 3600)   # rounded
-                println(mdfile, "| $rank | $author | $description | $location | $total_precip | $convection_share | $n_days |")
+                println(mdfile, "| $rank | $author | $description | $location | $total_precip | $convection_share | $snow_share | $n_days |")
             end
         end
     end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,7 +21,8 @@ function run_submission(path::String)
 
     # analyse/evaluate, skip first five days of measurements
     conv = rain_gauge.accumulated_rain_convection
-    snow = rain_gauge.accumulated_snow_large_scale
+    snow_conv = rain_gauge.accumulated_snow_convection
+    snow = rain_gauge.accumulated_snow_large_scale + rain_gauge.accumulated_snow_convection
 
     total_precip = maximum_precipitation(rain_gauge)
     submission_dict = Dict(
@@ -29,7 +30,7 @@ function run_submission(path::String)
         "description" => description,
         "location" => (rain_gauge.lond, rain_gauge.latd),
         "total precipitation" => total_precip,
-        "convection share" => maximum(conv) / total_precip,
+        "convection share" => (maximum(conv) + maximum(snow_conv)) / total_precip,
         "snow share" => maximum(snow) / total_precip,
         "period" => Second(rain_gauge.measurement_counter*rain_gauge.Δt) - Second(SKIP_START),
         "path" => path,

--- a/docs/src/instructions.md
+++ b/docs/src/instructions.md
@@ -16,7 +16,7 @@ but in short there are 4 steps
 using SpeedyWeather
 
 # 1. define the resolution
-spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 
 # 2. create a model
 model = PrimitiveWetModel(spectral_grid)
@@ -38,36 +38,37 @@ that is up to you to figure out.
 SpeedyWeather is a spectral model. That means it internally represents its variables
 as coefficients of horizontal waves on the sphere (the [_spherical harmonics_](https://en.wikipedia.org/wiki/Spherical_harmonics))
 up to a certain maximum wavenumber that is usually referred to as _truncation_.
-So for a truncation of 31, SpeedyWeather would resolve wavenumbers 0 to 31,
-but not 32 and larger. The higher the truncation the higher the resolution 
+So for `truncation=32`, SpeedyWeather would resolve wavenumbers 0 to 31,
+but not 32 and larger (note that `truncation` is 1-based, i.e. it counts the
+number of resolved wavenumbers including wavenumber 0). The higher the truncation the higher the resolution 
 and automatically chosen higher resolution of the grid. You control the resolution
-through the keyword argument `trunc` of the `SpectralGrid` object that defines
+through the keyword argument `truncation` of the `SpectralGrid` object that defines
 the resolution of a simulation
 
 ```@example instructions
 using SpeedyWeather
-spectral_grid =  SpectralGrid(trunc=42)
+spectral_grid =  SpectralGrid(truncation=42)
 ```
 
-Now change `trunc` (e.g. 31, 42, 63, 85, 127) and check what happens to
+Now change `truncation` (e.g. 32, 42, 64, 96, 128) and check what happens to
 precipitation when you run a simulation at that resolution. You can also change
 the number of vertical layers with the keyword argument `nlayers`, e.g.
 
 ```@example instructions
-spectral_grid =  SpectralGrid(trunc=31, nlayers=5)
+spectral_grid =  SpectralGrid(truncation=32, nlayers=5)
 ```
 
 Note however, that too many vertical layers can make the model unstable
 because of the (simpler) vertical advection that is used. This is not the place
 to elaborate on that, but just to warn you that `nlayers=100` is unlikely to "just work".
-Try to find out more generally, with changing `trunc` and `nlayers`
+Try to find out more generally, with changing `truncation` and `nlayers`
 
 - How does the grid spacing change?
 - How does the speed of the simulation change?
 
 Bonus question
 
-- Why 31, 42, 63, ... as given above? For more details see [Available horizontal resolutions](https://speedyweather.github.io/SpeedyWeather.jl/dev/spectral_transform/#Available-horizontal-resolutions) and [Matching spectral and grid resolution](https://speedyweather.github.io/SpeedyWeather.jl/dev/grids/#Matching-spectral-and-grid-resolution)
+- Why 32, 42, 64, ... as given above? For more details see [Available horizontal resolutions](https://speedyweather.github.io/SpeedyWeather.jl/dev/spectral_transform/#Available-horizontal-resolutions) and [Matching spectral and grid resolution](https://speedyweather.github.io/SpeedyWeather.jl/dev/grids/#Matching-spectral-and-grid-resolution)
 - How are the vertical layers spaced? Check `spectral_grid.vertical_coordinates` and read on [Sigma coordinates](https://speedyweather.github.io/SpeedyWeather.jl/dev/primitiveequation/#Sigma-coordinates)
 
 
@@ -78,14 +79,14 @@ many are still done in grid space. That's why people often call this method also
 You can control the grid through the argument `Grid`
 
 ```@example instructions
-spectral_grid =  SpectralGrid(trunc=31, Grid=FullGaussianGrid)
+spectral_grid =  SpectralGrid(truncation=32, Grid=FullGaussianGrid)
 ```
 
 Try `FullGaussianGrid`, `FullClenshawGrid`, `OctahedralGaussianGrid`, or `HEALPixGrid`
 among [others](https://speedyweather.github.io/SpeedyWeather.jl/dev/grids/). Do they
 have any impact on the simulated precipitation? More generally
 
-- Which grids have more, which fewer (horizontal) grid points at a given `trunc`?
+- Which grids have more, which fewer (horizontal) grid points at a given `truncation`?
 - On each grid, are the grid cells globally of similar size or not?
 - [Visualise](https://speedyweather.github.io/SpeedyWeather.jl/dev/grids/#Interactively-exploring-the-grids) the grids!
 
@@ -101,11 +102,11 @@ needs to know the spatial resolution to pick a time step by default that is stab
 SpeedyWeather's time integration is based on the `Leapfrog` scheme, so you create such a component like this
 
 ```@example instructions
-time_stepping = Leapfrog(spectral_grid, Δt_at_T31=Minute(20))
+time_stepping = Leapfrog(spectral_grid, Δt_at_T32=Minute(20))
 ```
 
-where the argument `Δt_at_T31` determines the timestep `Δt` (write `\Delta` then hit tab) relative to a truncation of
-31 (called T31), the actual time step is then in `Δt_sec`, scaled linearly from T31 to whatever resolution you chose.
+where the argument `Δt_at_T32` determines the timestep `Δt` (write `\Delta` then hit tab) relative to a truncation of
+32 (called T31, resolving wavenumbers 0 to 31), the actual time step is then in `Δt` (in seconds) and `Δt_millisec`, scaled linearly from T32 to whatever resolution you chose.
 You can provide any `Second`, `Minute`, `Hour` (but note that there is a stability limit above which your simulation quickly blows up).
 But do not forget to also pass this component to the model constructor, i.e.
 
@@ -118,7 +119,7 @@ where `; time_stepping` matches a keyword argument `time_stepping` with the vari
 to `, time_stepping=time_stepping`.
 
 
-- How large a time step can you choose for a T31 resolution?
+- How large a time step can you choose for a T31 resolution (`truncation=32`)?
 - How does the speed or simulation time change with a changed time step?
 
 Bonus question
@@ -138,7 +139,7 @@ You can change this start time when the model is initialized, i.e.
 
 ```@example instructions
 simulation = initialize!(model, time=DateTime(2000, 8, 1))
-simulation.prognostic_variables.clock
+simulation.variables.prognostic.clock
 ```
 
 With the last line you can inspect the `clock` object that keeps track of time.
@@ -259,7 +260,7 @@ simulation = initialize!(model)
 set!(model, land_sea_mask=0)    # all ocean!
 set!(simulation, sea_surface_temperature=(λ, φ) -> (30 < φ < 60) && (270 < λ < 360) ? 2 : 0, add=true)
 
-sst = simulation.prognostic_variables.ocean.sea_surface_temperature
+sst = simulation.variables.prognostic.ocean.sea_surface_temperature
 heatmap(sst, title="SST with +2K in North Atlantic")
 save("sst_2K.png", ans) # hide
 nothing # hide

--- a/docs/src/rain_gauge.md
+++ b/docs/src/rain_gauge.md
@@ -30,9 +30,16 @@ to reset the counter, time and all rainfall measurements.
 But a `RainGauge` is also mutable, meaning you can do
 this by hand too, e.g. `rain_gauge.accumulated_rain_large_scale .= 0`.
 
-`RainGauge` has two vectors `accumulated_rain_large_scale` and
-`accumulated_rain_convection` where every entry is one measurement
-of the given precipitation type at the specified location.
+`RainGauge` has three vectors `accumulated_rain_large_scale`,
+`accumulated_rain_convection` and `accumulated_snow_large_scale`
+where every entry is one measurement of the given precipitation type
+at the specified location. SpeedyWeather distinguishes rain from snow
+in its large-scale condensation (snow that melts on the way down is
+reclassified as rain), while convection produces rain only -- hence
+there is no `accumulated_snow_convection`. Snow is measured as liquid
+water equivalent so that `maximum_precipitation(rain_gauge)`, the total
+precipitation, is simply the sum of the three.
+
 One measurement is taken after every time step of the model simulation.
 In order to preallocate these vectors we use `max_measurements`
 as length, meaning those are the maximum number of measurements
@@ -196,14 +203,14 @@ beginning of the simulation to better understand regional rainfall patterns.
 SpeedyWeather uses largely SI units internally, but `RainGauge` converts
 meters to millimeters because that is the more common unit for rainfall.
 If we read out SpeedyWeather's fields manually we therefore have to do
-this conversion manually too. Total precipitation is the sum of convective
-and large-scale precipitation which we can calculate and visualise like this
+this conversion manually too. Total precipitation is the sum of convective rain, large-scale rain
+and large-scale snow which we can calculate and visualise like this
 
 ```@example rain_gauge
 # (; a, b) = struct unpacks the fields a, b in struct identified by name, equivalent to
 # a = struct.a and b = struct.b
-(; precip_large_scale, precip_convection) = simulation.diagnostic_variables.physics
-total_precipitation = precip_large_scale + precip_convection
+(; rain_large_scale, rain_convection, snow_large_scale) = simulation.variables.parameterizations
+total_precipitation = rain_large_scale + rain_convection + snow_large_scale
 total_precipitation *= 1000    # convert m to mm
 
 using CairoMakie
@@ -218,8 +225,9 @@ the model is initialized with `simulation = initialize!(model)` which constructs
 variables, initialized with zeros, too. This means the accumulation will
 continue across several `run!` calls unless you manually set it back via
 ```@example rain_gauge
-simulation.diagnostic_variables.physics.precip_large_scale .= 0
-simulation.diagnostic_variables.physics.precip_convection .= 0
+simulation.variables.parameterizations.rain_large_scale .= 0
+simulation.variables.parameterizations.rain_convection .= 0
+simulation.variables.parameterizations.snow_large_scale .= 0
 nothing # hide
 ```
 The `.` here is important to specify the broadcasting of the scalar `0` on the right

--- a/docs/src/rain_gauge.md
+++ b/docs/src/rain_gauge.md
@@ -30,15 +30,22 @@ to reset the counter, time and all rainfall measurements.
 But a `RainGauge` is also mutable, meaning you can do
 this by hand too, e.g. `rain_gauge.accumulated_rain_large_scale .= 0`.
 
-`RainGauge` has three vectors `accumulated_rain_large_scale`,
-`accumulated_rain_convection` and `accumulated_snow_large_scale`
-where every entry is one measurement of the given precipitation type
-at the specified location. SpeedyWeather distinguishes rain from snow
-in its large-scale condensation (snow that melts on the way down is
-reclassified as rain), while convection produces rain only -- hence
-there is no `accumulated_snow_convection`. Snow is measured as liquid
-water equivalent so that `maximum_precipitation(rain_gauge)`, the total
-precipitation, is simply the sum of the three.
+`RainGauge` has four vectors `accumulated_rain_large_scale`,
+`accumulated_rain_convection`, `accumulated_snow_large_scale` and
+`accumulated_snow_convection` where every entry is one measurement
+of the given precipitation type at the specified location. SpeedyWeather
+distinguishes rain from snow in both its large-scale condensation and its
+convection, so the four vectors are the combinations of the two schemes
+with the two phases. Snow is measured as liquid water equivalent so that
+`maximum_precipitation(rain_gauge)`, the total precipitation, is simply
+the sum of the four.
+
+Each of the four is read out independently and falls back to zero if the
+model does not define it. So a `RainGauge` also works in setups where a
+given precipitation type never occurs, e.g. a model without convection,
+or a SpeedyWeather version that does not diagnose convective snow yet --
+in those cases the corresponding vector just stays zero rather than
+erroring.
 
 One measurement is taken after every time step of the model simulation.
 In order to preallocate these vectors we use `max_measurements`
@@ -203,14 +210,14 @@ beginning of the simulation to better understand regional rainfall patterns.
 SpeedyWeather uses largely SI units internally, but `RainGauge` converts
 meters to millimeters because that is the more common unit for rainfall.
 If we read out SpeedyWeather's fields manually we therefore have to do
-this conversion manually too. Total precipitation is the sum of convective rain, large-scale rain
-and large-scale snow which we can calculate and visualise like this
+this conversion manually too. Total precipitation is the sum of large-scale and
+convective rain and snow which we can calculate and visualise like this
 
 ```@example rain_gauge
 # (; a, b) = struct unpacks the fields a, b in struct identified by name, equivalent to
 # a = struct.a and b = struct.b
-(; rain_large_scale, rain_convection, snow_large_scale) = simulation.variables.parameterizations
-total_precipitation = rain_large_scale + rain_convection + snow_large_scale
+(; rain_large_scale, rain_convection, snow_large_scale, snow_convection) = simulation.variables.parameterizations
+total_precipitation = rain_large_scale + rain_convection + snow_large_scale + snow_convection
 total_precipitation *= 1000    # convert m to mm
 
 using CairoMakie
@@ -228,6 +235,7 @@ continue across several `run!` calls unless you manually set it back via
 simulation.variables.parameterizations.rain_large_scale .= 0
 simulation.variables.parameterizations.rain_convection .= 0
 simulation.variables.parameterizations.snow_large_scale .= 0
+simulation.variables.parameterizations.snow_convection .= 0
 nothing # hide
 ```
 The `.` here is important to specify the broadcasting of the scalar `0` on the right

--- a/src/rain_gauge.jl
+++ b/src/rain_gauge.jl
@@ -6,16 +6,16 @@ const DEFAULT_PERIOD = Dates.Day(20)
 
 export RainGauge
 
-"""Measures convective and large-scale precipitation across time at
-one given location with linear interpolation from model grids onto
-`lond`, `latd`. Fields are 
+"""Measures convective and large-scale rain as well as large-scale snow
+across time at one given location with linear interpolation from model
+grids onto `lond`, `latd`. Fields are
 $(TYPEDFIELDS)"""
 @kwdef mutable struct RainGauge{NF, Interpolator} <: SpeedyWeather.AbstractCallback
-    
+
     # SPACE
     """[OPTION] Longitude [0 to 360˚E] where to measure precipitation."""
     lond::Float64 = DEFAULT_LOND
-    
+
     """[OPTION] Latitude [-90˚ to 90˚N] where to measure precipitation."""
     latd::Float64 = DEFAULT_LATD
 
@@ -35,24 +35,30 @@ $(TYPEDFIELDS)"""
     """Spacing between time steps."""
     Δt::Dates.Second = DEFAULT_ΔT
 
-    """Accumulated large-scale precipitation [mm] in the simulation at the beginning of rain gauge measurements."""
+    """Accumulated large-scale rain [mm] in the simulation at the beginning of rain gauge measurements."""
     accumulated_rain_large_scale_start::NF = 0
 
-    """Accumulated large-scale precipitation [mm] in the simulation at the beginning of rain gauge measurements."""
+    """Accumulated convective rain [mm] in the simulation at the beginning of rain gauge measurements."""
     accumulated_rain_convection_start::NF = 0
 
-    """Accumulated large-scale precipitation [mm]."""
+    """Accumulated large-scale snow [mm] in the simulation at the beginning of rain gauge measurements."""
+    accumulated_snow_large_scale_start::NF = 0
+
+    """Accumulated large-scale rain [mm]."""
     accumulated_rain_large_scale::Vector{NF} = zeros(NF, max_measurements)
-    
-    """Accumulated convective precipitation [mm]."""
+
+    """Accumulated convective rain [mm]."""
     accumulated_rain_convection::Vector{NF} = zeros(NF, max_measurements)
+
+    """Accumulated large-scale snow [mm], as liquid water equivalent."""
+    accumulated_snow_large_scale::Vector{NF} = zeros(NF, max_measurements)
 end
 
 # use number format NF from spectral grid if not provided
 function RainGauge(SG::SpectralGrid; kwargs...)
     npoints = 1
-    (; NF, Grid, nlat_half) = SG
-    interpolator = RingGrids.DEFAULT_INTERPOLATOR(Grid, nlat_half, npoints; NF)
+    (; NF, grid) = SG
+    interpolator = RingGrids.DEFAULT_INTERPOLATOR(grid, npoints; NF)
     RainGauge{SG.NF, typeof(interpolator)}(; interpolator, kwargs...)
 end
 
@@ -74,10 +80,22 @@ function Base.show(io::IO, gauge::RainGauge{T}) where T
 
     println(io, "├ accumulated_rain_large_scale::Vector{$T}, maximum: $(maximum(gauge.accumulated_rain_large_scale)) mm")
     println(io, "├ accumulated_rain_convection::Vector{$T}, maximum: $(maximum(gauge.accumulated_rain_convection)) mm")
-    
-    total_precip = maximum(gauge.accumulated_rain_large_scale) + maximum(gauge.accumulated_rain_convection)
-    total_precip_str = Printf.@sprintf("%.3f", total_precip)
+    println(io, "├ accumulated_snow_large_scale::Vector{$T}, maximum: $(maximum(gauge.accumulated_snow_large_scale)) mm")
+
+    total_precip_str = Printf.@sprintf("%.3f", maximum_precipitation(gauge))
     print(io,   "└ accumulated total precipitation: $total_precip_str mm")
+end
+
+export maximum_precipitation
+
+"""$(TYPEDSIGNATURES)
+Total accumulated precipitation [mm] measured by `gauge`, i.e. the sum of
+large-scale rain, convective rain and large-scale snow (as liquid water
+equivalent) at the last measurement."""
+function maximum_precipitation(gauge::RainGauge)
+    return maximum(gauge.accumulated_rain_large_scale) +
+        maximum(gauge.accumulated_rain_convection) +
+        maximum(gauge.accumulated_snow_large_scale)
 end
 
 """$(TYPEDSIGNATURES)
@@ -101,7 +119,19 @@ function reset!(gauge::RainGauge)
     gauge.Δt = DEFAULT_ΔT
     fill!(gauge.accumulated_rain_convection, 0)
     fill!(gauge.accumulated_rain_large_scale, 0)
+    fill!(gauge.accumulated_snow_large_scale, 0)
     return gauge
+end
+
+"""$(TYPEDSIGNATURES)
+Interpolate the accumulated precipitation variable `name` (e.g. `:rain_large_scale`)
+from `vars.parameterizations` onto the location of `gauge`. Returns 0 if the model
+does not define that variable, e.g. a dry model without large-scale condensation."""
+function measure(gauge::RainGauge{NF}, vars::SpeedyWeather.Variables, name::Symbol) where NF
+    haskey(vars.parameterizations, name) || return zero(NF)
+    precip = zeros(NF, 1)   # interpolate! requires a vector
+    RingGrids.interpolate!(precip, vars.parameterizations[name], gauge.interpolator)
+    return precip[1]
 end
 
 """$(TYPEDSIGNATURES)
@@ -109,20 +139,16 @@ Reset `gauge::RainGauge` to its initial state, but use time and Δt from
 clock."""
 function reset!(
     gauge::RainGauge,
-    progn::PrognosticVariables,
-    diagn::DiagnosticVariables,
+    vars::SpeedyWeather.Variables,
     model::SpeedyWeather.AbstractModel)
-    
+
     reset!(gauge)
-    gauge.tstart = progn.clock.time
-    gauge.Δt = progn.clock.Δt
+    gauge.tstart = vars.prognostic.clock.time
+    gauge.Δt = vars.prognostic.clock.Δt
 
-    p0 = zeros(1)
-    RingGrids.interpolate!(p0, diagn.physics.precip_large_scale, gauge.interpolator)
-    gauge.accumulated_rain_large_scale_start = p0[1]
-
-    RingGrids.interpolate!(p0, diagn.physics.precip_convection, gauge.interpolator)
-    gauge.accumulated_rain_convection_start = p0[1]
+    gauge.accumulated_rain_large_scale_start = measure(gauge, vars, :rain_large_scale)
+    gauge.accumulated_rain_convection_start = measure(gauge, vars, :rain_convection)
+    gauge.accumulated_snow_large_scale_start = measure(gauge, vars, :snow_large_scale)
 
     return nothing
 end
@@ -136,7 +162,7 @@ function skip!(rain_gauge::RainGauge, period::Dates.Period)
     @assert period >= Second(0) "Cannot skip negative period $period"
     t_end = rain_gauge.measurement_counter*rain_gauge.Δt
     @assert period <= t_end "Cannot skip $period, more than what was recorded for: $t_end"
-    
+
     # get index for timestep to normalize to 0, this "skips" the previous time steps
     # in the accumulated rainfall and makes their rainfall negative, doesn't affect
     # the rain rate but changes the accumulated rainfall at the last time step to
@@ -146,17 +172,21 @@ function skip!(rain_gauge::RainGauge, period::Dates.Period)
 
     lsc = rain_gauge.accumulated_rain_large_scale
     conv = rain_gauge.accumulated_rain_convection
-    
+    snow = rain_gauge.accumulated_snow_large_scale
+
     lsc0 = lsc[i]       # values that we will normalize with
     conv0 = conv[i]
+    snow0 = snow[i]
 
     # set the start values first which are used in case the rain gauge is started after the simulation
     rain_gauge.accumulated_rain_large_scale_start -= lsc0
     rain_gauge.accumulated_rain_convection_start -= conv0
+    rain_gauge.accumulated_snow_large_scale_start -= snow0
 
     # normalize, only the range of values that have already been measured
     lsc[1:rain_gauge.measurement_counter] .-= lsc0
     conv[1:rain_gauge.measurement_counter] .-= conv0
+    snow[1:rain_gauge.measurement_counter] .-= snow0
 
     return rain_gauge
 end
@@ -170,13 +200,12 @@ end
 
 """$(TYPEDSIGNATURES)
 Callback definition for `gauge::RainGauge` from `RainMaker.jl`.
-Interpolates large-scale and convective precipitation to the gauge's
-storage vectors and converts units from m to mm. Stops measuring if the
+Interpolates large-scale and convective rain as well as large-scale snow
+to the gauge's storage vectors and converts units from m to mm. Stops measuring if the
 `max_measurements` are reached which is printed only once as info."""
 function SpeedyWeather.callback!(
     gauge::RainGauge,
-    progn::PrognosticVariables,
-    diagn::DiagnosticVariables,
+    vars::SpeedyWeather.Variables,
     model::SpeedyWeather.AbstractModel)
 
     gauge.measurement_counter += 1      # always count up
@@ -185,18 +214,15 @@ function SpeedyWeather.callback!(
     gauge.measurement_counter > gauge.max_measurements && return nothing
     i = gauge.measurement_counter
 
-    # rain gauge measurements are relative to amount of precipitation at initial conditions
-    precip_lsc_0 = gauge.accumulated_rain_large_scale_start
-    precip_conv_0 = gauge.accumulated_rain_convection_start
-
-    # interpolate! requires vector, allocate but reuse
-    precip = zeros(1)
     m2mm = 1000     # model uses meters internally, convert to mm
-    RingGrids.interpolate!(precip, diagn.physics.precip_large_scale, gauge.interpolator)
-    gauge.accumulated_rain_large_scale[i] = (precip[1] - precip_lsc_0)*m2mm
 
-    RingGrids.interpolate!(precip, diagn.physics.precip_convection, gauge.interpolator)
-    gauge.accumulated_rain_convection[i] = (precip[1] - precip_conv_0)*m2mm
+    # rain gauge measurements are relative to amount of precipitation at initial conditions
+    gauge.accumulated_rain_large_scale[i] =
+        (measure(gauge, vars, :rain_large_scale) - gauge.accumulated_rain_large_scale_start)*m2mm
+    gauge.accumulated_rain_convection[i] =
+        (measure(gauge, vars, :rain_convection) - gauge.accumulated_rain_convection_start)*m2mm
+    gauge.accumulated_snow_large_scale[i] =
+        (measure(gauge, vars, :snow_large_scale) - gauge.accumulated_snow_large_scale_start)*m2mm
 
     # print info that max time steps is reached only once
     if gauge.measurement_counter == gauge.max_measurements
@@ -210,7 +236,8 @@ SpeedyWeather.finalize!(gauge::RainGauge, args...) = nothing
 
 """$(TYPEDSIGNATURES)
 Plot accumulated precipitation and precipitation rate across time for
-`gauge::RainGauge` from `RainMaker.jl`. `rate_Δt` specifies the interval
+`gauge::RainGauge` from `RainMaker.jl`. Large-scale rain, convective rain
+and large-scale snow are stacked. `rate_Δt` specifies the interval
 used to bin the precipitation rate, while units are always converted to
 mm/day. Default is 6 hours."""
 function plot(
@@ -231,7 +258,7 @@ function plot(
         ylabel="Accumulated [mm]")
 
     ax2 = Axis(fig[2, 1],
-        ylabel="Rate [mm/day]", 
+        ylabel="Rate [mm/day]",
         xlabel="time [days]")
 
     linkxaxes!(ax1, ax2)
@@ -243,37 +270,43 @@ function plot(
     # range of recorded precipitation only
     lsca = gauge.accumulated_rain_large_scale[1:gauge.measurement_counter]
     conv = gauge.accumulated_rain_convection[1:gauge.measurement_counter]
+    snow = gauge.accumulated_snow_large_scale[1:gauge.measurement_counter]
 
     # band/fillbetween plot, but stack them
-    band!(ax1, t, 0, lsca, label="large-scale condensation", color=:skyblue, alpha=0.8)
-    band!(ax1, t, lsca, conv+lsca, label="convection", color=:purple3, alpha=0.8)
-    
+    band!(ax1, t, 0, lsca, label="large-scale condensation (rain)", color=:skyblue, alpha=0.8)
+    band!(ax1, t, lsca, conv+lsca, label="convection (rain)", color=:purple3, alpha=0.8)
+    band!(ax1, t, conv+lsca, snow+conv+lsca, label="large-scale condensation (snow)", color=:aliceblue, alpha=0.8)
+
     # also plot total precipitation and add last value to legend
-    max_precip = Printf.@sprintf("%.3f", maximum(lsca) + maximum(conv))
-    lines!(ax1, t, conv+lsca, label="total: $max_precip mm", color=:black, alpha=0.8)
-    
+    max_precip = Printf.@sprintf("%.3f", maximum_precipitation(gauge))
+    lines!(ax1, t, snow+conv+lsca, label="total: $max_precip mm", color=:black, alpha=0.8)
+
     # add dashed line to indicate skipped days
     if skip > Second(0)
         vlines!(ax1, Second(skip).value/3600/24, linestyle=:dash, color=:black, label="First $skip skipped")
     end
 
     axislegend(ax1, position=:lt, labelsize=10)
-    
+
     # PRECIPITATION RATE
     # use every s-th value to reduce number of bars
     s = round(Int, Second(rate_Δt).value / Second(gauge.Δt).value)
-    
+
     # convert from mm to mm/day
     mm2mmday = Day(1)/(s*Second(gauge.Δt))
     lsc0 = gauge.accumulated_rain_large_scale_start
     conv0 = gauge.accumulated_rain_convection_start
+    snow0 = gauge.accumulated_snow_large_scale_start
     lsca_rate = diff(vcat(lsc0, lsca[s:s:end]))*mm2mmday
     conv_rate = diff(vcat(conv0, conv[s:s:end]))*mm2mmday
+    snow_rate = diff(vcat(snow0, snow[s:s:end]))*mm2mmday
     t_rate = t[s:s:end]     # also subset time vector
 
     # Makie's barplot requires stacked bars to be concatenated?!
-    color = vcat(fill(:skyblue, length(t_rate)), fill(:purple3, length(t_rate)))
-    barplot!(ax2, vcat(t_rate, t_rate), vcat(lsca_rate, conv_rate), stack=fill(2, 2*length(t_rate)); color, alpha=0.8)
+    n = length(t_rate)
+    color = vcat(fill(:skyblue, n), fill(:purple3, n), fill(:aliceblue, n))
+    barplot!(ax2, vcat(t_rate, t_rate, t_rate), vcat(lsca_rate, conv_rate, snow_rate),
+        stack=vcat(fill(1, n), fill(2, n), fill(3, n)); color, alpha=0.8)
 
     return fig
 end

--- a/src/rain_gauge.jl
+++ b/src/rain_gauge.jl
@@ -6,9 +6,11 @@ const DEFAULT_PERIOD = Dates.Day(20)
 
 export RainGauge
 
-"""Measures convective and large-scale rain as well as large-scale snow
-across time at one given location with linear interpolation from model
-grids onto `lond`, `latd`. Fields are
+"""Measures convective and large-scale rain and snow across time at
+one given location with linear interpolation from model grids onto
+`lond`, `latd`. Precipitation types that the model does not define
+(e.g. convective snow with older SpeedyWeather versions, or any
+precipitation in a dry model) are measured as zero. Fields are
 $(TYPEDFIELDS)"""
 @kwdef mutable struct RainGauge{NF, Interpolator} <: SpeedyWeather.AbstractCallback
 
@@ -44,6 +46,9 @@ $(TYPEDFIELDS)"""
     """Accumulated large-scale snow [mm] in the simulation at the beginning of rain gauge measurements."""
     accumulated_snow_large_scale_start::NF = 0
 
+    """Accumulated convective snow [mm] in the simulation at the beginning of rain gauge measurements."""
+    accumulated_snow_convection_start::NF = 0
+
     """Accumulated large-scale rain [mm]."""
     accumulated_rain_large_scale::Vector{NF} = zeros(NF, max_measurements)
 
@@ -52,6 +57,9 @@ $(TYPEDFIELDS)"""
 
     """Accumulated large-scale snow [mm], as liquid water equivalent."""
     accumulated_snow_large_scale::Vector{NF} = zeros(NF, max_measurements)
+
+    """Accumulated convective snow [mm], as liquid water equivalent."""
+    accumulated_snow_convection::Vector{NF} = zeros(NF, max_measurements)
 end
 
 # use number format NF from spectral grid if not provided
@@ -81,6 +89,7 @@ function Base.show(io::IO, gauge::RainGauge{T}) where T
     println(io, "├ accumulated_rain_large_scale::Vector{$T}, maximum: $(maximum(gauge.accumulated_rain_large_scale)) mm")
     println(io, "├ accumulated_rain_convection::Vector{$T}, maximum: $(maximum(gauge.accumulated_rain_convection)) mm")
     println(io, "├ accumulated_snow_large_scale::Vector{$T}, maximum: $(maximum(gauge.accumulated_snow_large_scale)) mm")
+    println(io, "├ accumulated_snow_convection::Vector{$T}, maximum: $(maximum(gauge.accumulated_snow_convection)) mm")
 
     total_precip_str = Printf.@sprintf("%.3f", maximum_precipitation(gauge))
     print(io,   "└ accumulated total precipitation: $total_precip_str mm")
@@ -90,12 +99,13 @@ export maximum_precipitation
 
 """$(TYPEDSIGNATURES)
 Total accumulated precipitation [mm] measured by `gauge`, i.e. the sum of
-large-scale rain, convective rain and large-scale snow (as liquid water
-equivalent) at the last measurement."""
+large-scale and convective rain and snow (snow as liquid water equivalent)
+at the last measurement."""
 function maximum_precipitation(gauge::RainGauge)
     return maximum(gauge.accumulated_rain_large_scale) +
         maximum(gauge.accumulated_rain_convection) +
-        maximum(gauge.accumulated_snow_large_scale)
+        maximum(gauge.accumulated_snow_large_scale) +
+        maximum(gauge.accumulated_snow_convection)
 end
 
 """$(TYPEDSIGNATURES)
@@ -120,13 +130,15 @@ function reset!(gauge::RainGauge)
     fill!(gauge.accumulated_rain_convection, 0)
     fill!(gauge.accumulated_rain_large_scale, 0)
     fill!(gauge.accumulated_snow_large_scale, 0)
+    fill!(gauge.accumulated_snow_convection, 0)
     return gauge
 end
 
 """$(TYPEDSIGNATURES)
 Interpolate the accumulated precipitation variable `name` (e.g. `:rain_large_scale`)
 from `vars.parameterizations` onto the location of `gauge`. Returns 0 if the model
-does not define that variable, e.g. a dry model without large-scale condensation."""
+does not define that variable, e.g. a dry model without large-scale condensation,
+or a SpeedyWeather version that does not diagnose convective snow yet."""
 function measure(gauge::RainGauge{NF}, vars::SpeedyWeather.Variables, name::Symbol) where NF
     haskey(vars.parameterizations, name) || return zero(NF)
     precip = zeros(NF, 1)   # interpolate! requires a vector
@@ -149,6 +161,7 @@ function reset!(
     gauge.accumulated_rain_large_scale_start = measure(gauge, vars, :rain_large_scale)
     gauge.accumulated_rain_convection_start = measure(gauge, vars, :rain_convection)
     gauge.accumulated_snow_large_scale_start = measure(gauge, vars, :snow_large_scale)
+    gauge.accumulated_snow_convection_start = measure(gauge, vars, :snow_convection)
 
     return nothing
 end
@@ -172,21 +185,25 @@ function skip!(rain_gauge::RainGauge, period::Dates.Period)
 
     lsc = rain_gauge.accumulated_rain_large_scale
     conv = rain_gauge.accumulated_rain_convection
-    snow = rain_gauge.accumulated_snow_large_scale
+    snow_lsc = rain_gauge.accumulated_snow_large_scale
+    snow_conv = rain_gauge.accumulated_snow_convection
 
     lsc0 = lsc[i]       # values that we will normalize with
     conv0 = conv[i]
-    snow0 = snow[i]
+    snow_lsc0 = snow_lsc[i]
+    snow_conv0 = snow_conv[i]
 
     # set the start values first which are used in case the rain gauge is started after the simulation
     rain_gauge.accumulated_rain_large_scale_start -= lsc0
     rain_gauge.accumulated_rain_convection_start -= conv0
-    rain_gauge.accumulated_snow_large_scale_start -= snow0
+    rain_gauge.accumulated_snow_large_scale_start -= snow_lsc0
+    rain_gauge.accumulated_snow_convection_start -= snow_conv0
 
     # normalize, only the range of values that have already been measured
     lsc[1:rain_gauge.measurement_counter] .-= lsc0
     conv[1:rain_gauge.measurement_counter] .-= conv0
-    snow[1:rain_gauge.measurement_counter] .-= snow0
+    snow_lsc[1:rain_gauge.measurement_counter] .-= snow_lsc0
+    snow_conv[1:rain_gauge.measurement_counter] .-= snow_conv0
 
     return rain_gauge
 end
@@ -200,7 +217,7 @@ end
 
 """$(TYPEDSIGNATURES)
 Callback definition for `gauge::RainGauge` from `RainMaker.jl`.
-Interpolates large-scale and convective rain as well as large-scale snow
+Interpolates large-scale and convective rain and snow
 to the gauge's storage vectors and converts units from m to mm. Stops measuring if the
 `max_measurements` are reached which is printed only once as info."""
 function SpeedyWeather.callback!(
@@ -223,6 +240,8 @@ function SpeedyWeather.callback!(
         (measure(gauge, vars, :rain_convection) - gauge.accumulated_rain_convection_start)*m2mm
     gauge.accumulated_snow_large_scale[i] =
         (measure(gauge, vars, :snow_large_scale) - gauge.accumulated_snow_large_scale_start)*m2mm
+    gauge.accumulated_snow_convection[i] =
+        (measure(gauge, vars, :snow_convection) - gauge.accumulated_snow_convection_start)*m2mm
 
     # print info that max time steps is reached only once
     if gauge.measurement_counter == gauge.max_measurements
@@ -236,8 +255,8 @@ SpeedyWeather.finalize!(gauge::RainGauge, args...) = nothing
 
 """$(TYPEDSIGNATURES)
 Plot accumulated precipitation and precipitation rate across time for
-`gauge::RainGauge` from `RainMaker.jl`. Large-scale rain, convective rain
-and large-scale snow are stacked. `rate_Δt` specifies the interval
+`gauge::RainGauge` from `RainMaker.jl`. Large-scale rain, convective rain,
+large-scale snow and convective snow are stacked. `rate_Δt` specifies the interval
 used to bin the precipitation rate, while units are always converted to
 mm/day. Default is 6 hours."""
 function plot(
@@ -270,16 +289,24 @@ function plot(
     # range of recorded precipitation only
     lsca = gauge.accumulated_rain_large_scale[1:gauge.measurement_counter]
     conv = gauge.accumulated_rain_convection[1:gauge.measurement_counter]
-    snow = gauge.accumulated_snow_large_scale[1:gauge.measurement_counter]
+    snow_lsc = gauge.accumulated_snow_large_scale[1:gauge.measurement_counter]
+    snow_conv = gauge.accumulated_snow_convection[1:gauge.measurement_counter]
+
+    # cumulative sums to stack the four components on top of each other
+    stack1 = lsca
+    stack2 = stack1 + conv
+    stack3 = stack2 + snow_lsc
+    stack4 = stack3 + snow_conv
 
     # band/fillbetween plot, but stack them
-    band!(ax1, t, 0, lsca, label="large-scale condensation (rain)", color=:skyblue, alpha=0.8)
-    band!(ax1, t, lsca, conv+lsca, label="convection (rain)", color=:purple3, alpha=0.8)
-    band!(ax1, t, conv+lsca, snow+conv+lsca, label="large-scale condensation (snow)", color=:aliceblue, alpha=0.8)
+    band!(ax1, t, 0, stack1, label="large-scale condensation (rain)", color=:skyblue, alpha=0.8)
+    band!(ax1, t, stack1, stack2, label="convection (rain)", color=:purple3, alpha=0.8)
+    band!(ax1, t, stack2, stack3, label="large-scale condensation (snow)", color=:aliceblue, alpha=0.8)
+    band!(ax1, t, stack3, stack4, label="convection (snow)", color=:plum, alpha=0.8)
 
     # also plot total precipitation and add last value to legend
     max_precip = Printf.@sprintf("%.3f", maximum_precipitation(gauge))
-    lines!(ax1, t, snow+conv+lsca, label="total: $max_precip mm", color=:black, alpha=0.8)
+    lines!(ax1, t, stack4, label="total: $max_precip mm", color=:black, alpha=0.8)
 
     # add dashed line to indicate skipped days
     if skip > Second(0)
@@ -296,17 +323,20 @@ function plot(
     mm2mmday = Day(1)/(s*Second(gauge.Δt))
     lsc0 = gauge.accumulated_rain_large_scale_start
     conv0 = gauge.accumulated_rain_convection_start
-    snow0 = gauge.accumulated_snow_large_scale_start
+    snow_lsc0 = gauge.accumulated_snow_large_scale_start
+    snow_conv0 = gauge.accumulated_snow_convection_start
     lsca_rate = diff(vcat(lsc0, lsca[s:s:end]))*mm2mmday
     conv_rate = diff(vcat(conv0, conv[s:s:end]))*mm2mmday
-    snow_rate = diff(vcat(snow0, snow[s:s:end]))*mm2mmday
+    snow_lsc_rate = diff(vcat(snow_lsc0, snow_lsc[s:s:end]))*mm2mmday
+    snow_conv_rate = diff(vcat(snow_conv0, snow_conv[s:s:end]))*mm2mmday
     t_rate = t[s:s:end]     # also subset time vector
 
     # Makie's barplot requires stacked bars to be concatenated?!
     n = length(t_rate)
-    color = vcat(fill(:skyblue, n), fill(:purple3, n), fill(:aliceblue, n))
-    barplot!(ax2, vcat(t_rate, t_rate, t_rate), vcat(lsca_rate, conv_rate, snow_rate),
-        stack=vcat(fill(1, n), fill(2, n), fill(3, n)); color, alpha=0.8)
+    color = vcat(fill(:skyblue, n), fill(:purple3, n), fill(:aliceblue, n), fill(:plum, n))
+    barplot!(ax2, vcat(t_rate, t_rate, t_rate, t_rate),
+        vcat(lsca_rate, conv_rate, snow_lsc_rate, snow_conv_rate),
+        stack=vcat(fill(1, n), fill(2, n), fill(3, n), fill(4, n)); color, alpha=0.8)
 
     return fig
 end

--- a/submissions/anas-nn_surrogate_v2.jl
+++ b/submissions/anas-nn_surrogate_v2.jl
@@ -26,8 +26,8 @@ end
 
 function max_precipitation(parameters::NamedTuple)
 
-    # define resolution. Use trunc=42, 63, 85, 127, ... for higher resolution, cubically slower
-    spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+    # define resolution. Use truncation=64, 96, 128, 192, ... for higher resolution, cubically slower
+    spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 
     # Define AquaPlanet ocean, for idealised sea surface temperatures
     # but don't change land-sea mask = retain real ocean basins

--- a/submissions/anas_submission.jl
+++ b/submissions/anas_submission.jl
@@ -26,8 +26,8 @@ end
 
 function max_precipitation(parameters::NamedTuple)
 
-    # define resolution. Use trunc=42, 63, 85, 127, ... for higher resolution, cubically slower
-    spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+    # define resolution. Use truncation=64, 96, 128, 192, ... for higher resolution, cubically slower
+    spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 
     # Define AquaPlanet ocean, for idealised sea surface temperatures
     # but don't change land-sea mask = retain real ocean basins

--- a/submissions/anicusan_evoopt_bounded.jl
+++ b/submissions/anicusan_evoopt_bounded.jl
@@ -25,8 +25,8 @@ end
 
 function max_precipitation(parameters::NamedTuple)
 
-    # define resolution. Use trunc=42, 63, 85, 127, ... for higher resolution, cubically slower
-    spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+    # define resolution. Use truncation=64, 96, 128, 192, ... for higher resolution, cubically slower
+    spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 
     # Define AquaPlanet ocean, for idealised sea surface temperatures
     # but don't change land-sea mask = retain real ocean basins

--- a/submissions/anicusan_evoopt_unbounded.jl
+++ b/submissions/anicusan_evoopt_unbounded.jl
@@ -25,8 +25,8 @@ end
 
 function max_precipitation(parameters::NamedTuple)
 
-    # define resolution. Use trunc=42, 63, 85, 127, ... for higher resolution, cubically slower
-    spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+    # define resolution. Use truncation=64, 96, 128, 192, ... for higher resolution, cubically slower
+    spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 
     # Define AquaPlanet ocean, for idealised sea surface temperatures
     # but don't change land-sea mask = retain real ocean basins

--- a/submissions/aquaplanet.jl
+++ b/submissions/aquaplanet.jl
@@ -3,7 +3,7 @@ description = "Aquaplanet"
 
 using SpeedyWeather, RainMaker
 
-spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 
 # define aquaplanet
 ocean = AquaPlanet(spectral_grid, temp_equator=302, temp_poles=273)

--- a/submissions/aquaplanet_mountain.jl
+++ b/submissions/aquaplanet_mountain.jl
@@ -3,7 +3,7 @@ description = "Aqua-planet simulation with a mountain"
 
 using SpeedyWeather, RainMaker
 
-spectral_grid = SpectralGrid(trunc=31, nlayers=10)
+spectral_grid = SpectralGrid(truncation=32, nlayers=10)
 model = PrimitiveWetModel(spectral_grid)
 
 # Set up aqauaplanet but add large mountain in "North Sea" after initialization!

--- a/submissions/atlantic_mountain.jl
+++ b/submissions/atlantic_mountain.jl
@@ -3,7 +3,7 @@ description = "Atlantic mountain"
 
 using SpeedyWeather, RainMaker
 
-spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 model = PrimitiveWetModel(spectral_grid)
 
 rain_gauge = RainGauge(spectral_grid, lond=-80, latd=40.45)

--- a/submissions/bieganek_latin_hypercube.jl
+++ b/submissions/bieganek_latin_hypercube.jl
@@ -45,8 +45,8 @@ end
 
 function max_precipitation(parameters::NamedTuple)
 
-    # define resolution. Use trunc=42, 63, 85, 127, ... for higher resolution, cubically slower
-    spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+    # define resolution. Use truncation=64, 96, 128, 192, ... for higher resolution, cubically slower
+    spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 
     # Define AquaPlanet ocean, for idealised sea surface temperatures
     # but don't change land-sea mask = retain real ocean basins

--- a/submissions/chris_brute_force.jl
+++ b/submissions/chris_brute_force.jl
@@ -48,8 +48,8 @@ end
 
 function max_precipitation(parameters::NamedTuple)
 
-    # define resolution. Use trunc=42, 63, 85, 127, ... for higher resolution, cubically slower
-    spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+    # define resolution. Use truncation=64, 96, 128, 192, ... for higher resolution, cubically slower
+    spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 
     # Define AquaPlanet ocean, for idealised sea surface temperatures
     # but don't change land-sea mask = retain real ocean basins

--- a/submissions/chris_evotrees.jl
+++ b/submissions/chris_evotrees.jl
@@ -74,8 +74,8 @@ end
 
 function max_precipitation(parameters::NamedTuple)
 
-    # define resolution. Use trunc=42, 63, 85, 127, ... for higher resolution, cubically slower
-    spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+    # define resolution. Use truncation=64, 96, 128, 192, ... for higher resolution, cubically slower
+    spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 
     # Define AquaPlanet ocean, for idealised sea surface temperatures
     # but don't change land-sea mask = retain real ocean basins

--- a/submissions/default.jl
+++ b/submissions/default.jl
@@ -3,7 +3,7 @@ description = "default"
 
 using SpeedyWeather, RainMaker
 
-spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 model = PrimitiveWetModel(spectral_grid)
 
 rain_gauge = RainGauge(spectral_grid, lond=-80, latd=40.45)

--- a/submissions/gabrielks_brute_force_1.jl
+++ b/submissions/gabrielks_brute_force_1.jl
@@ -111,8 +111,8 @@ end
 
 function max_precipitation(parameters::NamedTuple)
 
-    # define resolution. Use trunc=42, 63, 85, 127, ... for higher resolution, cubically slower
-    spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+    # define resolution. Use truncation=64, 96, 128, 192, ... for higher resolution, cubically slower
+    spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 
     # Define AquaPlanet ocean, for idealised sea surface temperatures
     # but don't change land-sea mask = retain real ocean basins

--- a/submissions/nathan_xgboost
+++ b/submissions/nathan_xgboost
@@ -72,8 +72,8 @@ end
 
 function max_precipitation(parameters::NamedTuple)
 
-    # define resolution. Use trunc=42, 63, 85, 127, ... for higher resolution, cubically slower
-    spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+    # define resolution. Use truncation=64, 96, 128, 192, ... for higher resolution, cubically slower
+    spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 
     # Define AquaPlanet ocean, for idealised sea surface temperatures
     # but don't change land-sea mask = retain real ocean basins

--- a/submissions/north_sea_mountain.jl
+++ b/submissions/north_sea_mountain.jl
@@ -3,7 +3,7 @@ description = "North Sea mountain"
 
 using SpeedyWeather, RainMaker
 
-spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 model = PrimitiveWetModel(spectral_grid)
 
 rain_gauge = RainGauge(spectral_grid, lond=-80, latd=40.45)

--- a/submissions/theo_juliacon.jl
+++ b/submissions/theo_juliacon.jl
@@ -74,8 +74,8 @@ end
 
 function max_precipitation(parameters::NamedTuple)
 
-    # define resolution. Use trunc=42, 63, 85, 127, ... for higher resolution, cubically slower
-    spectral_grid = SpectralGrid(trunc=31, nlayers=8)
+    # define resolution. Use truncation=64, 96, 128, 192, ... for higher resolution, cubically slower
+    spectral_grid = SpectralGrid(truncation=32, nlayers=8)
 
     # Define AquaPlanet ocean, for idealised sea surface temperatures
     # but don't change land-sea mask = retain real ocean basins

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,63 @@
 using RainMaker
+using SpeedyWeather
 using Test
 
 @testset "RainMaker.jl" begin
-    @test true
+
+    @testset "RainGauge in a PrimitiveWetModel" begin
+        spectral_grid = SpectralGrid(truncation=32, nlayers=5)
+        rain_gauge = RainGauge(spectral_grid, lond=-1.25, latd=51.75)
+
+        model = PrimitiveWetModel(spectral_grid)
+        add!(model, rain_gauge)
+
+        simulation = initialize!(model)
+        model.feedback.verbose = false
+        run!(simulation, period=Day(2))
+
+        # one measurement per time step
+        @test rain_gauge.measurement_counter > 0
+
+        # rain and snow are separate and non-negative (accumulated)
+        i = rain_gauge.measurement_counter
+        @test all(rain_gauge.accumulated_rain_large_scale[1:i] .>= 0)
+        @test all(rain_gauge.accumulated_rain_convection[1:i] .>= 0)
+        @test all(rain_gauge.accumulated_snow_large_scale[1:i] .>= 0)
+
+        # total precipitation includes snow
+        @test maximum_precipitation(rain_gauge) ==
+            maximum(rain_gauge.accumulated_rain_large_scale) +
+            maximum(rain_gauge.accumulated_rain_convection) +
+            maximum(rain_gauge.accumulated_snow_large_scale)
+
+        # clock information picked up from the simulation
+        @test rain_gauge.Δt == Second(model.time_stepping.Δt_millisec)
+
+        # printing doesn't error
+        @test (show(devnull, rain_gauge); true)
+    end
+
+    @testset "reset! and skip!" begin
+        spectral_grid = SpectralGrid(truncation=32, nlayers=5)
+        rain_gauge = RainGauge(spectral_grid)
+
+        rain_gauge.measurement_counter = 10
+        rain_gauge.accumulated_rain_large_scale[1:10] .= 1:10
+        rain_gauge.accumulated_rain_convection[1:10] .= 1:10
+        rain_gauge.accumulated_snow_large_scale[1:10] .= 1:10
+
+        gauge2 = skip(rain_gauge, 5*rain_gauge.Δt)
+        @test gauge2.accumulated_rain_large_scale[5] == 0
+        @test gauge2.accumulated_snow_large_scale[5] == 0
+        @test gauge2.accumulated_rain_convection[10] == 5
+
+        # original untouched by non-mutating skip
+        @test rain_gauge.accumulated_snow_large_scale[5] == 5
+
+        RainMaker.reset!(rain_gauge)
+        @test rain_gauge.measurement_counter == 0
+        @test all(rain_gauge.accumulated_rain_large_scale .== 0)
+        @test all(rain_gauge.accumulated_rain_convection .== 0)
+        @test all(rain_gauge.accumulated_snow_large_scale .== 0)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,12 +23,14 @@ using Test
         @test all(rain_gauge.accumulated_rain_large_scale[1:i] .>= 0)
         @test all(rain_gauge.accumulated_rain_convection[1:i] .>= 0)
         @test all(rain_gauge.accumulated_snow_large_scale[1:i] .>= 0)
+        @test all(rain_gauge.accumulated_snow_convection[1:i] .>= 0)
 
-        # total precipitation includes snow
+        # total precipitation includes both snow types
         @test maximum_precipitation(rain_gauge) ==
             maximum(rain_gauge.accumulated_rain_large_scale) +
             maximum(rain_gauge.accumulated_rain_convection) +
-            maximum(rain_gauge.accumulated_snow_large_scale)
+            maximum(rain_gauge.accumulated_snow_large_scale) +
+            maximum(rain_gauge.accumulated_snow_convection)
 
         # clock information picked up from the simulation
         @test rain_gauge.Δt == Second(model.time_stepping.Δt_millisec)
@@ -45,10 +47,12 @@ using Test
         rain_gauge.accumulated_rain_large_scale[1:10] .= 1:10
         rain_gauge.accumulated_rain_convection[1:10] .= 1:10
         rain_gauge.accumulated_snow_large_scale[1:10] .= 1:10
+        rain_gauge.accumulated_snow_convection[1:10] .= 1:10
 
         gauge2 = skip(rain_gauge, 5*rain_gauge.Δt)
         @test gauge2.accumulated_rain_large_scale[5] == 0
         @test gauge2.accumulated_snow_large_scale[5] == 0
+        @test gauge2.accumulated_snow_convection[5] == 0
         @test gauge2.accumulated_rain_convection[10] == 5
 
         # original untouched by non-mutating skip
@@ -59,5 +63,23 @@ using Test
         @test all(rain_gauge.accumulated_rain_large_scale .== 0)
         @test all(rain_gauge.accumulated_rain_convection .== 0)
         @test all(rain_gauge.accumulated_snow_large_scale .== 0)
+        @test all(rain_gauge.accumulated_snow_convection .== 0)
+    end
+
+    @testset "Missing precipitation types measured as zero" begin
+        # a dry model defines none of the four precipitation variables, the gauge
+        # should record zeros throughout rather than error
+        spectral_grid = SpectralGrid(truncation=32, nlayers=5)
+        rain_gauge = RainGauge(spectral_grid)
+
+        model = PrimitiveDryModel(spectral_grid)
+        add!(model, rain_gauge)
+
+        simulation = initialize!(model)
+        model.feedback.verbose = false
+        run!(simulation, period=Day(1))
+
+        @test rain_gauge.measurement_counter > 0
+        @test maximum_precipitation(rain_gauge) == 0
     end
 end


### PR DESCRIPTION
SpeedyWeather has released several breaking versions since RainMaker's last release, so this updates the compat bound and adapts `RainGauge` to the new API, including the new rain/snow distinction.

## Compat

| package | before | after |
| --- | --- | --- |
| SpeedyWeather | `0.16` | `0.22` |
| julia | `1.10, 1.11` | `1.10` |

CairoMakie `0.15` and DocStringExtensions `0.9` are already the newest registered versions, so they are unchanged. The julia bound is widened so that 1.12 is allowed (SpeedyWeather itself only requires 1.10). Package version bumped to `0.3.0`.

## Variables moved

Two breaking changes in SpeedyWeather affect the `RainGauge` callback:

- precipitation diagnostics moved from `diagnostic_variables.physics.precip_large_scale` / `precip_convection` to `variables.parameterizations.rain_large_scale` / `rain_convection`
- callbacks now take `(callback, vars::Variables, model)` instead of `(callback, progn, diagn, model)`, and the clock is at `vars.prognostic.clock`

`RainGauge` is updated for both, and the interpolator is now built from `SG.grid` rather than the removed `Grid, nlat_half` pair.

## Rain vs. snow

SpeedyWeather now distinguishes rain from snow, so `RainGauge` records four vectors covering both schemes and both phases:

| | rain | snow |
| --- | --- | --- |
| **large-scale** | `accumulated_rain_large_scale` | `accumulated_snow_large_scale` |
| **convection** | `accumulated_rain_convection` | `accumulated_snow_convection` |

Snow is recorded as liquid water equivalent, so the new exported `maximum_precipitation(gauge)` is just the sum of the four.

Convective snow (`snow_convection`) is the variable added by SpeedyWeather/SpeedyWeather.jl#1221, which is still open. This PR reads it anyway: every one of the four types goes through a `measure` helper that checks `haskey(vars.parameterizations, name)` and returns 0 when the variable is absent. So convective snow simply stays zero until #1221 lands and starts recording itself afterwards with no further change here. The same guard means a gauge in a model without condensation or convection at all records zeros instead of erroring — there is a testset running a `PrimitiveDryModel` that covers this.

Other changes that follow:

- `reset!` and `skip!` handle all four vectors
- `RainMaker.plot` stacks four components in both the accumulation band plot and the rate bar plot
- the leaderboard gains a `Share snow [%]` column; `Share convection [%]` now counts convective rain *and* convective snow, so the two columns are orthogonal splits — one by scheme, one by phase

## Docs, README and submissions

Resolution is 1-based since SpeedyWeather#1177, so `trunc=31` becomes `truncation=32` and `Δt_at_T31` becomes `Δt_at_T32` throughout `docs/src/instructions.md`, `README.md` and all scripts in `submissions/`. `docs/src/rain_gauge.md` is updated for the new variable paths and explains the rain/snow split.

## Testing

`test/runtests.jl` was `@test true`; it now runs a short `PrimitiveWetModel` simulation with a gauge attached and checks all four accumulation vectors, the total, the clock pickup and `show`, plus testsets for `reset!`/`skip!` and for the dry-model fallback. Locally against SpeedyWeather v0.22.1 on julia 1.12:

```
Test Summary: | Pass  Total     Time
RainMaker.jl  |   20     20  3m49.9s
     Testing RainMaker tests passed
```

## Not verified

The doc build executes every script in `submissions/` end to end. I applied the mechanical `truncation` rename there, but those scripts also use ocean/land components and `set!` whose API may have shifted across the six minor versions since 0.16 — confirming each one still runs would need a full doc build, which I have not done. Worth a check before merging, since the leaderboard numbers will also shift now that snow counts toward the total.